### PR TITLE
Add Qt Quick Controls 2 variants for comparison

### DIFF
--- a/benchmark/creation/delegates_buttoncontrol2.qml
+++ b/benchmark/creation/delegates_buttoncontrol2.qml
@@ -1,0 +1,25 @@
+import QtQuick 2.0
+import QtQuick.Controls 2.0
+
+Item {
+    id: root;
+    property int count: 20;
+
+    property real t;
+    NumberAnimation on t { from: 0; to: 1; duration: 1000; loops: Animation.Infinite }
+    onTChanged: {
+        repeater.model = 0;
+        repeater.model = root.count
+    }
+
+    Component.onCompleted: repeater.model = root.count
+
+    Repeater {
+        id: repeater
+        Button {
+            x: Math.random() * root.width - width
+            y: Math.random() * root.height - height
+            text: "Item #" + index;
+        }
+    }
+}

--- a/benchmark/creation/delegates_labelcontrol2.qml
+++ b/benchmark/creation/delegates_labelcontrol2.qml
@@ -1,0 +1,25 @@
+import QtQuick 2.0
+import QtQuick.Controls 2.0
+
+Item {
+    id: root;
+    property int count: 20;
+
+    property real t;
+    NumberAnimation on t { from: 0; to: 1; duration: 1000; loops: Animation.Infinite }
+    onTChanged: {
+        repeater.model = 0;
+        repeater.model = root.count
+    }
+
+    Component.onCompleted: repeater.model = root.count
+
+    Repeater {
+        id: repeater
+        Label {
+            x: Math.random() * root.width - width
+            y: Math.random() * root.height - height
+            text: "Qt Quick!"
+        }
+    }
+}


### PR DESCRIPTION
On a Desktop PC with Ubuntu Desktop 16.04, Intel(R) Core(TM) i7-6600U CPU @
2.60GHz, Intel(R) HD Graphics 520 (Skylake GT2), 1280x800, 60fps, Qt
5.7, xcb, 3.0 Mesa 13.1.0-devel it looks roughly like this:

delegates_buttoncontrol.qml: 20 ops/frame
delegates_buttoncontrol2.qml: 119 ops/frame
delegates_labelcontrol.qml: 224 ops/frame
delegates_labelcontrol2.qml: 269 ops/frame

Signed-off-by: Christoph Settgast <christoph.settgast@methodpark.com>